### PR TITLE
Cannot find module './PathUtils' on case-sensitive filesystem

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const fuzzaldrin = require('fuzzaldrin');
-const PathUtils = require('./PathUtils');
+const PathUtils = require('./pathUtils');
 const Utils = {};
 
 


### PR DESCRIPTION
```
Error: Cannot find module './PathUtils'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/<private>/Alfred.alfredpreferences/workflows/user.workflow.E346CE7F-4ACB-455D-8029-8F2AACCE7935/lib/utils.js:6:19)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
```